### PR TITLE
Fix issue 138: SIM switch failure

### DIFF
--- a/core/src/com/gsma/rcs/service/StartService.java
+++ b/core/src/com/gsma/rcs/service/StartService.java
@@ -402,7 +402,7 @@ public class StartService extends Service {
                 if (logActivated) {
                     sLogger.info("Backup ".concat(mLastUserAccount));
                 }
-                BackupRestoreDb.backupAccount(mLastUserAccount);
+                BackupRestoreDb.tryBackupAccount(mLastUserAccount);
             }
 
             /* Reset RCS account */
@@ -417,7 +417,8 @@ public class StartService extends Service {
             if (logActivated) {
                 sLogger.info("Restore ".concat(mCurrentUserAccount));
             }
-            BackupRestoreDb.restoreAccount(mCurrentUserAccount);
+            BackupRestoreDb.tryRestoreAccount(mCurrentUserAccount);
+
             /*
              * Send service provisioned intent as the configuration settings are now loaded by means
              * of restoring previous values that were backed up during SIM Swap.

--- a/core/tests/src/com/gsma/rcs/br/DbBackupRestoreTest.java
+++ b/core/tests/src/com/gsma/rcs/br/DbBackupRestoreTest.java
@@ -64,17 +64,17 @@ public class DbBackupRestoreTest extends AndroidTestCase {
     }
 
     public void testBackupAccount() throws InterruptedException, IOException, RcsAccountException {
-        BackupRestoreDb.backupAccount("1111");
+²        BackupRestoreDb.tryBackupAccount("1111");
         /*
          * A timer greater than 1 second is set because some emulator have only an accuracy of 1
          * second.
          */
         Thread.sleep(1010);
-        BackupRestoreDb.backupAccount("2222");
+        BackupRestoreDb.tryBackupAccount("2222");
         Thread.sleep(1010);
-        BackupRestoreDb.backupAccount("3333");
+        BackupRestoreDb.tryBackupAccount("3333");
         Thread.sleep(1010);
-        BackupRestoreDb.backupAccount("4444");
+        BackupRestoreDb.tryBackupAccount("4444");
 
         mSavedAccounts = BackupRestoreDb.listOfSavedAccounts(mSrcdir);
         for (File file : mSavedAccounts) {
@@ -91,19 +91,19 @@ public class DbBackupRestoreTest extends AndroidTestCase {
         }
     }
 
-    public void testCleanBackups() throws InterruptedException, IOException, RcsAccountException {
+    public void testCleanBackups() throws InterruptedException, IOException {
         /* This cleanBackups removes the oldest directory (if MAX_SAVED_ACCOUNT is reached) */
-        BackupRestoreDb.backupAccount("1111");
+        BackupRestoreDb.tryBackupAccount("1111");
         /*
          * A timer greater than 1 second is set because some emulator have only an accuracy of 1
          * second.
          */
         Thread.sleep(1010);
-        BackupRestoreDb.backupAccount("2222");
+        BackupRestoreDb.tryBackupAccount("2222");
         Thread.sleep(1010);
-        BackupRestoreDb.backupAccount("3333");
+        BackupRestoreDb.tryBackupAccount("3333");
         Thread.sleep(1010);
-        BackupRestoreDb.backupAccount("4444");
+        BackupRestoreDb.tryBackupAccount("4444");
 
         BackupRestoreDb.cleanBackups("3333");
         mSavedAccounts = BackupRestoreDb.listOfSavedAccounts(mSrcdir);
@@ -122,9 +122,9 @@ public class DbBackupRestoreTest extends AndroidTestCase {
         }
     }
 
-    public void testRestoreDb() throws IOException, RcsAccountException {
-        BackupRestoreDb.backupAccount("2222");
-        BackupRestoreDb.restoreAccount("2222");
+    public void testRestoreDb() throws IOException {
+        BackupRestoreDb.tryBackupAccount("2222");
+        BackupRestoreDb.tryRestoreAccount("2222");
     }
 
 }


### PR DESCRIPTION
- If configuration restore fails because backup files does not exist then catch the RcsAccountException and continue processing to start the core stack.
- Same for configuration backup.
- Align core tests.