### PR TITLE
IMDN disposition notification is not mandatory

### DIFF
--- a/core/src/com/gsma/rcs/core/ims/service/im/chat/ChatSession.java
+++ b/core/src/com/gsma/rcs/core/ims/service/im/chat/ChatSession.java
@@ -557,12 +557,20 @@ public abstract class ChatSession extends ImsServiceSession implements MsrpEvent
                     } else {
                         // TODO : else return error to Originating side
                     }
+                    if (mImdnManager.isDeliveryDeliveredReportsEnabled()) {
+                        sendMsrpMessageDeliveryStatus(null, cpimMsgId,
+                                ImdnDocument.DELIVERY_STATUS_DELIVERED, timestamp);
+                    }
                 } else {
                     if (ChatUtils.isTextPlainType(contentType)) {
                         ChatMessage msg = new ChatMessage(cpimMsgId, contact,
                                 cpimMsg.getMessageContent(), MimeType.TEXT_MESSAGE, timestamp,
                                 timestampSent, null);
                         receive(msg, imdnDisplayedRequested);
+                        if (mImdnManager.isDeliveryDeliveredReportsEnabled()) {
+                            sendMsrpMessageDeliveryStatus(null, cpimMsgId,
+                                    ImdnDocument.DELIVERY_STATUS_DELIVERED, timestamp);
+                        }
                     } else if (ChatUtils.isApplicationIsComposingType(contentType)) {
                         receiveIsComposing(contact, cpimMsg.getMessageContent().getBytes(UTF8));
                     } else if (ChatUtils.isMessageImdnType(contentType)) {
@@ -572,20 +580,10 @@ public abstract class ChatSession extends ImsServiceSession implements MsrpEvent
                                 cpimMsg.getMessageContent(), GeolocInfoDocument.MIME_TYPE,
                                 timestamp, timestampSent, null);
                         receive(msg, imdnDisplayedRequested);
-                    }
-                }
-
-                if (!mImdnManager.isDeliveryDeliveredReportsEnabled()) {
-                    return;
-                }
-
-                if (isFToHTTP) {
-                    sendMsrpMessageDeliveryStatus(null, cpimMsgId,
-                            ImdnDocument.DELIVERY_STATUS_DELIVERED, timestamp);
-                } else {
-                    if (dispositionNotification != null) {
-                        sendMsrpMessageDeliveryStatus(null, cpimMsgId,
-                                ImdnDocument.DELIVERY_STATUS_DELIVERED, timestamp);
+                        if (mImdnManager.isDeliveryDeliveredReportsEnabled()) {
+                            sendMsrpMessageDeliveryStatus(null, cpimMsgId,
+                                    ImdnDocument.DELIVERY_STATUS_DELIVERED, timestamp);
+                        }
                     }
                 }
             }

--- a/core/src/com/gsma/rcs/core/ims/service/im/chat/GroupChatSession.java
+++ b/core/src/com/gsma/rcs/core/ims/service/im/chat/GroupChatSession.java
@@ -759,6 +759,10 @@ public abstract class GroupChatSession extends ChatSession {
                 ChatMessage msg = new ChatMessage(cpimMsgId, remoteId, cpimMsg.getMessageContent(),
                         MimeType.TEXT_MESSAGE, timestamp, timestampSent, pseudo);
                 receive(msg, shouldSendDisplayReport(dispositionNotification));
+                if (mImdnManager.isDeliveryDeliveredReportsEnabled()) {
+                    sendMsrpMessageDeliveryStatus(remoteId, cpimMsgId,
+                            ImdnDocument.DELIVERY_STATUS_DELIVERED, timestamp);
+                }
             } else {
                 if (ChatUtils.isApplicationIsComposingType(contentType)) {
                     // Is composing event
@@ -789,13 +793,13 @@ public abstract class GroupChatSession extends ChatSession {
                                     cpimMsg.getMessageContent(), GeolocInfoDocument.MIME_TYPE,
                                     timestamp, timestampSent, pseudo);
                             receive(msg, shouldSendDisplayReport(dispositionNotification));
+                            if (mImdnManager.isDeliveryDeliveredReportsEnabled()) {
+                                sendMsrpMessageDeliveryStatus(remoteId, cpimMsgId,
+                                        ImdnDocument.DELIVERY_STATUS_DELIVERED, timestamp);
+                            }
                         }
                     }
                 }
-            }
-            if (dispositionNotification != null) {
-                sendMsrpMessageDeliveryStatus(remoteId, cpimMsgId,
-                        ImdnDocument.DELIVERY_STATUS_DELIVERED, timestamp);
             }
         }
     }


### PR DESCRIPTION
We discovered in our testing that a test network removes the imdn.Disposition-Notification part of the header when relaying group chat messages and based on discussions with Kristoffer we should still send delivery responses for messages, geoloc shares and filetransfers.

I am posting info about this patch to Kristoffer, hopefully he will have a chance to look at it tomorrow.