### PR TITLE
Reverted sendEmptyMsrpSendRequest method removal

### DIFF
--- a/core/src/com/gsma/rcs/core/ims/protocol/msrp/MsrpManager.java
+++ b/core/src/com/gsma/rcs/core/ims/protocol/msrp/MsrpManager.java
@@ -310,8 +310,10 @@ public class MsrpManager {
 
     /**
      * Send an empty chunk
+     * 
+     * @throws NetworkException
      */
-    public void sendEmptyChunk() {
+    public void sendEmptyChunk() throws NetworkException {
         mMsrpSession.sendEmptyChunk();
     }
 

--- a/core/src/com/gsma/rcs/core/ims/service/im/chat/ChatSession.java
+++ b/core/src/com/gsma/rcs/core/ims/service/im/chat/ChatSession.java
@@ -640,8 +640,10 @@ public abstract class ChatSession extends ImsServiceSession implements MsrpEvent
 
     /**
      * Send an empty data chunk
+     * 
+     * @throws NetworkException
      */
-    public void sendEmptyDataChunk() {
+    public void sendEmptyDataChunk() throws NetworkException {
         mMsrpMgr.sendEmptyChunk();
     }
 

--- a/core/src/com/gsma/rcs/core/ims/service/im/chat/standfw/TerminatingStoreAndForwardOneToOneChatNotificationSession.java
+++ b/core/src/com/gsma/rcs/core/ims/service/im/chat/standfw/TerminatingStoreAndForwardOneToOneChatNotificationSession.java
@@ -373,8 +373,10 @@ public class TerminatingStoreAndForwardOneToOneChatNotificationSession extends O
 
     /**
      * Send an empty data chunk
+     * 
+     * @throws NetworkException
      */
-    public void sendEmptyDataChunk() {
+    public void sendEmptyDataChunk() throws NetworkException {
         mMsrpMgr.sendEmptyChunk();
     }
 

--- a/core/src/com/gsma/rcs/core/ims/service/richcall/geoloc/TerminatingGeolocTransferSession.java
+++ b/core/src/com/gsma/rcs/core/ims/service/richcall/geoloc/TerminatingGeolocTransferSession.java
@@ -310,8 +310,10 @@ public class TerminatingGeolocTransferSession extends GeolocTransferSession impl
 
     /**
      * Send an empty data chunk
+     * 
+     * @throws NetworkException
      */
-    public void sendEmptyDataChunk() {
+    public void sendEmptyDataChunk() throws NetworkException {
         msrpMgr.sendEmptyChunk();
     }
 

--- a/core/src/com/gsma/rcs/core/ims/service/richcall/image/TerminatingImageTransferSession.java
+++ b/core/src/com/gsma/rcs/core/ims/service/richcall/image/TerminatingImageTransferSession.java
@@ -334,8 +334,10 @@ public class TerminatingImageTransferSession extends ImageTransferSession implem
 
     /**
      * Send an empty data chunk
+     * 
+     * @throws NetworkException
      */
-    public void sendEmptyDataChunk() {
+    public void sendEmptyDataChunk() throws NetworkException {
         msrpMgr.sendEmptyChunk();
     }
 


### PR DESCRIPTION
sendEmptyMsrpSendRequest() called from MsrpSession
sendEmptyChunk() got removed in earlier patches, which
introduced a regression, Fixed the same.
Also made changes to have proper exception handling for
this method.

Change-Id: I956b0ddfed042b33b7c0cd3b5bd49f2fea05684e