### PR TITLE
Fix for double STARTED broadcasts

### DIFF
--- a/core/src/com/gsma/rcs/provider/messaging/GroupChatLog.java
+++ b/core/src/com/gsma/rcs/provider/messaging/GroupChatLog.java
@@ -244,8 +244,6 @@ public class GroupChatLog implements IGroupChatLog {
         }
         ContentValues values = new ContentValues();
         values.put(GroupChatData.KEY_REJOIN_ID, rejoinId);
-        values.put(GroupChatData.KEY_STATE, State.STARTED.toInt());
-        values.put(GroupChatData.KEY_REASON_CODE, ReasonCode.UNSPECIFIED.toInt());
         return mLocalContentResolver.update(
                 Uri.withAppendedPath(GroupChatData.CONTENT_URI, chatId), values, null, null) > 0;
     }

--- a/core/src/com/gsma/rcs/service/api/GroupChatImpl.java
+++ b/core/src/com/gsma/rcs/service/api/GroupChatImpl.java
@@ -1472,8 +1472,10 @@ public class GroupChatImpl extends IGroupChat.Stub implements GroupChatSessionLi
                     }
                 }
             }
-            if (mPersistedStorage.setRejoinId(session.getImSessionIdentity())) {
-                mBroadcaster.broadcastStateChanged(mChatId, State.STARTED, ReasonCode.UNSPECIFIED);
+            mPersistedStorage.setRejoinId(session.getImSessionIdentity());
+            if (State.STARTED != mPersistedStorage.getState()) {
+                mChatService.setGroupChatStateAndReasonCode(mChatId, State.STARTED,
+                        ReasonCode.UNSPECIFIED);
             }
         }
         mImService.tryToInviteQueuedGroupChatParticipantInvitations(mChatId);


### PR DESCRIPTION
Refactoring GroupChatLog.setRejoinId to remove setting chat state
as side-effect. This separation was necessary since we only want
to set and broadcast STARTED in case the group chat isn't already
STARTED.