### PR TITLE
Render headings in `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ RCS-e stack for Android with GSMA API **RCS-e stack for Android with GSMA API**
 
 The RCS-e stack is an open source implementation of the Rich Communication Suite standards for Google Android platform. This implementation is compliant to GSMA RCS-e Blackbird standards. Thanks to its client/server API, the stack may be easily integrated with existing native Android applications (e.g. address book, dialer) and permits to create new RCS applications (e.g. chat, widgets).
 
-##About RCS, Rich Communication Suite:
+## About RCS, Rich Communication Suite:
 
 The Rich Communication Suite Initiative is a GSM Association programme dedicated to deliver convergent rich communication services. RCS should be the first set of services using IMS architecture in the mobile field. "joyn" is the commercial name of RCS.
 
@@ -15,7 +15,7 @@ The RCS specifications (product, technical, API, Guidelines) are available at [h
 
 Note: the [supported standards](https://rawgit.com/android-rcs/rcsjta/master/docs/SUPPORTED-STANDARDS.txt).
 
-##Licensing:
+## Licensing:
 The RCS core stack is under [Apache 2 license](https://rawgit.com/android-rcs/rcsjta/master/core/LICENSE-2.0.txt) and uses the following open source libraries:
 
 - the SIP stack comes from [NIST-SIP project] (http://jsip.java.net/'>http://jsip.java.net/), see [License](https://rawgit.com/android-rcs/rcsjta/master/core/LICENSE-NIST.txt).
@@ -24,13 +24,13 @@ The RCS core stack is under [Apache 2 license](https://rawgit.com/android-rcs/rc
 
 - the cryptography API comes from Legion of the [Bouncy Castle Inc] (https://www.bouncycastle.org/), see [License](https://rawgit.com/android-rcs/rcsjta/master/core/LICENSE-BOUNCYCASTLE.txt).
 
-##Project:
+## Project:
 
 - see [Project management](https://rawgit.com/android-rcs/rcsjta/master/docs/RCSJTA_open_source.ppt).
 
 - see [GIT branches](https://github.com/android-rcs/rcsjta/blob/wiki/Branches.md).
 
-##RCS API definition:
+## RCS API definition:
 
 - TAPI 1.5
 
@@ -46,15 +46,15 @@ The RCS core stack is under [Apache 2 license](https://rawgit.com/android-rcs/rc
   * see [TAPI 1.6.1 Javadoc] (https://rawgit.com/android-rcs/rcsjta.javadoc/javadoc1.6/index.html).
 
 
-##SDK nightly builds:
+## SDK nightly builds:
 - see latest SDK of [tapi_1.5](https://github.com/android-rcs/rcsjta.build/tree/tapi_1.5) branch.
 - see latest SDK of [tapi_1.6](https://github.com/android-rcs/rcsjta.build/tree/tapi_1.6) branch.
 
-##Stack overview:
+## Stack overview:
 
 <img src='https://github.com/android-rcs/rcsjta/blob/master/docs/website/overview.png'><br>
 
-##More docs:
+## More docs:
 
 - see [Wiki](https://github.com/android-rcs/rcsjta/wiki).
 


### PR DESCRIPTION
Fixed heading syntax in `README.md`. They now render as `<H2>`s.