### PR TITLE
Fix build for Gradle >8.5 and modern build tools

### DIFF
--- a/RI/build.gradle
+++ b/RI/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'com.gsma.rcs.ri'
 
     //Required to support the old folder structure
     sourceSets {
@@ -8,7 +9,6 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
             resources.srcDirs = ['src']
-            aidl.srcDirs = ['src']
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']

--- a/RI/build.gradle
+++ b/RI/build.gradle
@@ -20,12 +20,12 @@ android {
     //Required to support builds although lint errors exist
     lintOptions {
         abortOnError false
-		disable 'IconLocation'
+        disable 'IconLocation'
         disable 'IconDuplicates'
-		disable 'IconDuplicatesConfig'
-		disable 'IconColors'
-		disable 'IconMissingDensityFolder'
-		disable 'IconDensities'
+        disable 'IconDuplicatesConfig'
+        disable 'IconColors'
+        disable 'IconMissingDensityFolder'
+        disable 'IconDensities'
     }
 
     compileSdkVersion rootProject.compileSdkVersion
@@ -42,17 +42,19 @@ android {
 }
 
 dependencies {
-    compile project(':api')
-    compile project(':api_cnx')
-    compile project(':mediaplayer')
-    compile 'com.android.support:support-v4:25.0.1'
-	compile 'com.google.android.gms:play-services:8.4.0'
+    implementation project(':api')
+    implementation project(':api_cnx')
+    implementation project(':mediaplayer')
+    implementation 'com.android.support:support-v4:25.0.1'
+    implementation 'com.google.android.gms:play-services:8.4.0'
 }
 
 //Below install dependecy was added to always install RCS service before
 //a RCS client to secure that Android handles RCS permissions correctly.
-task installServiceFirst(dependsOn: ':core:installDebug') << {
-    println 'RCS core service was installed first!'
+task installServiceFirst(dependsOn: ':core:installDebug') {
+    doLast {
+        println 'RCS core service was installed first!'
+    }
 }
 tasks.whenTaskAdded { task ->
     if (task.name == 'installDebug') {

--- a/RI/src/com/gsma/rcs/ri/extension/messaging/MessagingSessionView.java
+++ b/RI/src/com/gsma/rcs/ri/extension/messaging/MessagingSessionView.java
@@ -326,10 +326,8 @@ public class MessagingSessionView extends RcsActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_close_session:
-                quitSession();
-                break;
+        if (item.getItemId() == R.id.menu_close_session) {
+            quitSession();
         }
         return true;
     }

--- a/RI/src/com/gsma/rcs/ri/extension/streaming/StreamingSessionView.java
+++ b/RI/src/com/gsma/rcs/ri/extension/streaming/StreamingSessionView.java
@@ -344,10 +344,8 @@ public class StreamingSessionView extends RcsActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_close_session:
-                quitSession();
-                break;
+        if (item.getItemId() == R.id.menu_close_session) {
+            quitSession();
         }
         return true;
     }

--- a/RI/src/com/gsma/rcs/ri/messaging/GroupTalkView.java
+++ b/RI/src/com/gsma/rcs/ri/messaging/GroupTalkView.java
@@ -643,46 +643,40 @@ public class GroupTalkView extends RcsFragmentActivity implements
             Log.d(LOGTAG, "onContextItemSelected Id=".concat(id));
         }
         try {
-            switch (item.getItemId()) {
-                case R.id.menu_view_group_delivery:
-                    GroupDeliveryInfoList.startActivity(this, id);
+            int itemId = item.getItemId();
+            if (itemId == R.id.menu_view_group_delivery) {
+                GroupDeliveryInfoList.startActivity(this, id);
+                return true;
+            } else if (itemId == R.id.menu_delete_message) {
+                if (Message.HISTORYLOG_MEMBER_ID == providerId) {
+                    mChatService.deleteMessage(id);
+                } else {
+                    mFileTransferService.deleteFileTransfer(id);
+                }
+                return true;
+            } else if (itemId == R.id.menu_view_detail) {
+                if (Message.HISTORYLOG_MEMBER_ID == providerId) {
+                    ChatMessageLogView.startActivity(this, id);
+                } else {
+                    FileTransferLogView.startActivity(this, id);
+                }
+                return true;
+            } else if (itemId == R.id.menu_display_content) {
+                if (FileTransferLog.HISTORYLOG_MEMBER_ID == providerId) {
+                    String file = cursor.getString(cursor
+                            .getColumnIndexOrThrow(HistoryLog.CONTENT));
+                    Utils.showPicture(this, Uri.parse(file));
+                    markFileTransferAsRead(cursor, id);
                     return true;
-
-                case R.id.menu_delete_message:
-                    if (ChatLog.Message.HISTORYLOG_MEMBER_ID == providerId) {
-                        mChatService.deleteMessage(id);
-                    } else {
-                        mFileTransferService.deleteFileTransfer(id);
-                    }
+                }
+            } else if (itemId == R.id.menu_listen_content) {
+                if (FileTransferLog.HISTORYLOG_MEMBER_ID == providerId) {
+                    String file = cursor.getString(cursor
+                            .getColumnIndexOrThrow(HistoryLog.CONTENT));
+                    Utils.playAudio(this, Uri.parse(file));
+                    markFileTransferAsRead(cursor, id);
                     return true;
-
-                case R.id.menu_view_detail:
-                    if (ChatLog.Message.HISTORYLOG_MEMBER_ID == providerId) {
-                        ChatMessageLogView.startActivity(this, id);
-                    } else {
-                        FileTransferLogView.startActivity(this, id);
-                    }
-                    return true;
-
-                case R.id.menu_display_content:
-                    if (FileTransferLog.HISTORYLOG_MEMBER_ID == providerId) {
-                        String file = cursor.getString(cursor
-                                .getColumnIndexOrThrow(HistoryLog.CONTENT));
-                        Utils.showPicture(this, Uri.parse(file));
-                        markFileTransferAsRead(cursor, id);
-                        return true;
-                    }
-                    break;
-
-                case R.id.menu_listen_content:
-                    if (FileTransferLog.HISTORYLOG_MEMBER_ID == providerId) {
-                        String file = cursor.getString(cursor
-                                .getColumnIndexOrThrow(HistoryLog.CONTENT));
-                        Utils.playAudio(this, Uri.parse(file));
-                        markFileTransferAsRead(cursor, id);
-                        return true;
-                    }
-                    break;
+                }
             }
             return super.onContextItemSelected(item);
         } catch (RcsServiceException e) {
@@ -954,59 +948,45 @@ public class GroupTalkView extends RcsFragmentActivity implements
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         try {
-            switch (item.getItemId()) {
-                case R.id.menu_insert_smiley:
-                    AlertDialog alert = Smileys.showSmileyDialog(this, mComposeText,
-                            getResources(), getString(R.string.menu_insert_smiley));
-                    registerDialog(alert);
-                    break;
-
-                case R.id.menu_participants:
-                    alert = Utils.showList(this, getString(R.string.menu_participants),
-                            getSetOfParticipants(mGroupChat.getParticipants()));
-                    registerDialog(alert);
-                    break;
-
-                case R.id.menu_add_participant:
-                    addParticipants();
-                    break;
-
-                case R.id.menu_quicktext:
-                    addQuickText();
-                    break;
-
-                case R.id.menu_send_file:
-                    SendGroupFile.startActivity(this, mChatId);
-                    break;
-
-                case R.id.menu_send_geoloc:
-                    getGeoLoc();
-                    break;
-
-                case R.id.menu_showus_map:
-                    DisplayGeoloc.showContactsOnMap(this, mGroupChat.getParticipants().keySet());
-                    break;
-
-                case R.id.menu_close_session:
-                    AlertDialog.Builder builder = new AlertDialog.Builder(this);
-                    builder.setTitle(R.string.title_chat_exit);
-                    builder.setPositiveButton(R.string.label_ok,
-                            new DialogInterface.OnClickListener() {
-                                public void onClick(DialogInterface dialog, int which) {
-                                    if (mGroupChat != null) {
-                                        try {
-                                            mGroupChat.leave();
-                                        } catch (RcsServiceException e) {
-                                            showExceptionThenExit(e);
-                                        }
+            int itemId = item.getItemId();
+            if (itemId == R.id.menu_insert_smiley) {
+                AlertDialog alert = Smileys.showSmileyDialog(this, mComposeText,
+                        getResources(), getString(R.string.menu_insert_smiley));
+                registerDialog(alert);
+            } else if (itemId == R.id.menu_participants) {
+                AlertDialog alert;
+                alert = Utils.showList(this, getString(R.string.menu_participants),
+                        getSetOfParticipants(mGroupChat.getParticipants()));
+                registerDialog(alert);
+            } else if (itemId == R.id.menu_add_participant) {
+                addParticipants();
+            } else if (itemId == R.id.menu_quicktext) {
+                addQuickText();
+            } else if (itemId == R.id.menu_send_file) {
+                SendGroupFile.startActivity(this, mChatId);
+            } else if (itemId == R.id.menu_send_geoloc) {
+                getGeoLoc();
+            } else if (itemId == R.id.menu_showus_map) {
+                DisplayGeoloc.showContactsOnMap(this, mGroupChat.getParticipants().keySet());
+            } else if (itemId == R.id.menu_close_session) {
+                AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                builder.setTitle(R.string.title_chat_exit);
+                builder.setPositiveButton(R.string.label_ok,
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int which) {
+                                if (mGroupChat != null) {
+                                    try {
+                                        mGroupChat.leave();
+                                    } catch (RcsServiceException e) {
+                                        showExceptionThenExit(e);
                                     }
-                                    GroupTalkView.this.finish();
                                 }
-                            });
-                    builder.setNegativeButton(R.string.label_cancel, null);
-                    builder.setCancelable(true);
-                    registerDialog(builder.show());
-                    break;
+                                GroupTalkView.this.finish();
+                            }
+                        });
+                builder.setNegativeButton(R.string.label_cancel, null);
+                builder.setCancelable(true);
+                registerDialog(builder.show());
             }
 
         } catch (RcsServiceException e) {

--- a/RI/src/com/gsma/rcs/ri/messaging/OneToOneTalkView.java
+++ b/RI/src/com/gsma/rcs/ri/messaging/OneToOneTalkView.java
@@ -628,20 +628,14 @@ public class OneToOneTalkView extends RcsFragmentActivity implements
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         try {
-            switch (item.getItemId()) {
-                case R.id.menu_send_geoloc:
-                    /* Start a new activity to select a geolocation */
-                    startActivityForResult(new Intent(this, EditGeoloc.class), SELECT_GEOLOCATION);
-                    break;
-
-                case R.id.menu_send_rcs_file:
-                    SendSingleFile.startActivity(this, mContact);
-                    break;
-
-                case R.id.menu_delete_talk:
-                    mFileTransferService.deleteOneToOneFileTransfers(mContact);
-                    mChatService.deleteOneToOneChat(mContact);
-                    break;
+            int itemId = item.getItemId();
+            if (itemId == R.id.menu_send_geoloc) {/* Start a new activity to select a geolocation */
+                startActivityForResult(new Intent(this, EditGeoloc.class), SELECT_GEOLOCATION);
+            } else if (itemId == R.id.menu_send_rcs_file) {
+                SendSingleFile.startActivity(this, mContact);
+            } else if (itemId == R.id.menu_delete_talk) {
+                mFileTransferService.deleteOneToOneFileTransfers(mContact);
+                mChatService.deleteOneToOneChat(mContact);
             }
         } catch (RcsServiceException e) {
             showExceptionThenExit(e);
@@ -748,67 +742,58 @@ public class OneToOneTalkView extends RcsFragmentActivity implements
             Log.d(LOGTAG, "onContextItemSelected Id=".concat(id));
         }
         try {
-            switch (item.getItemId()) {
-                case R.id.menu_delete_message:
-                    switch (providerId) {
-                        case ChatLog.Message.HISTORYLOG_MEMBER_ID:
-                            mChatService.deleteMessage(id);
-                            return true;
-                        case FileTransferLog.HISTORYLOG_MEMBER_ID:
-                            mFileTransferService.deleteFileTransfer(id);
-                            return true;
-                    }
-                    break;
+            int itemId = item.getItemId();
+            if (itemId == R.id.menu_delete_message) {
+                switch (providerId) {
+                    case ChatLog.Message.HISTORYLOG_MEMBER_ID:
+                        mChatService.deleteMessage(id);
+                        return true;
+                    case FileTransferLog.HISTORYLOG_MEMBER_ID:
+                        mFileTransferService.deleteFileTransfer(id);
+                        return true;
+                }
+            } else if (itemId == R.id.menu_resend_message) {
+                switch (providerId) {
+                    case ChatLog.Message.HISTORYLOG_MEMBER_ID:
+                        OneToOneChat chat = mChatService.getOneToOneChat(mContact);
+                        if (chat != null) {
+                            chat.resendMessage(id);
+                        }
+                        return true;
 
-                case R.id.menu_resend_message:
-                    switch (providerId) {
-                        case ChatLog.Message.HISTORYLOG_MEMBER_ID:
-                            OneToOneChat chat = mChatService.getOneToOneChat(mContact);
-                            if (chat != null) {
-                                chat.resendMessage(id);
-                            }
-                            return true;
-
-                        case FileTransferLog.HISTORYLOG_MEMBER_ID:
-                            FileTransfer fileTransfer = mFileTransferService.getFileTransfer(id);
-                            if (fileTransfer != null) {
-                                fileTransfer.resendTransfer();
-                            }
-                            return true;
-                    }
-                    break;
-
-                case R.id.menu_display_content:
-                    switch (providerId) {
-                        case FileTransferLog.HISTORYLOG_MEMBER_ID:
-                            String file = cursor.getString(cursor
-                                    .getColumnIndexOrThrow(HistoryLog.CONTENT));
-                            Utils.showPicture(this, Uri.parse(file));
-                            markFileTransferAsRead(cursor, id);
-                            return true;
-                    }
-                    break;
-
-                case R.id.menu_view_detail:
-                    switch (providerId) {
-                        case ChatLog.Message.HISTORYLOG_MEMBER_ID:
-                            ChatMessageLogView.startActivity(this, id);
-                            return true;
-                        case FileTransferLog.HISTORYLOG_MEMBER_ID:
-                            FileTransferLogView.startActivity(this, id);
-                            return true;
-                    }
-                    break;
-
-                case R.id.menu_listen_content:
-                    if (FileTransferLog.HISTORYLOG_MEMBER_ID == providerId) {
+                    case FileTransferLog.HISTORYLOG_MEMBER_ID:
+                        FileTransfer fileTransfer = mFileTransferService.getFileTransfer(id);
+                        if (fileTransfer != null) {
+                            fileTransfer.resendTransfer();
+                        }
+                        return true;
+                }
+            } else if (itemId == R.id.menu_display_content) {
+                switch (providerId) {
+                    case FileTransferLog.HISTORYLOG_MEMBER_ID:
                         String file = cursor.getString(cursor
                                 .getColumnIndexOrThrow(HistoryLog.CONTENT));
-                        Utils.playAudio(this, Uri.parse(file));
+                        Utils.showPicture(this, Uri.parse(file));
                         markFileTransferAsRead(cursor, id);
                         return true;
-                    }
-                    break;
+                }
+            } else if (itemId == R.id.menu_view_detail) {
+                switch (providerId) {
+                    case ChatLog.Message.HISTORYLOG_MEMBER_ID:
+                        ChatMessageLogView.startActivity(this, id);
+                        return true;
+                    case FileTransferLog.HISTORYLOG_MEMBER_ID:
+                        FileTransferLogView.startActivity(this, id);
+                        return true;
+                }
+            } else if (itemId == R.id.menu_listen_content) {
+                if (FileTransferLog.HISTORYLOG_MEMBER_ID == providerId) {
+                    String file = cursor.getString(cursor
+                            .getColumnIndexOrThrow(HistoryLog.CONTENT));
+                    Utils.playAudio(this, Uri.parse(file));
+                    markFileTransferAsRead(cursor, id);
+                    return true;
+                }
             }
             return super.onContextItemSelected(item);
 

--- a/RI/src/com/gsma/rcs/ri/messaging/TalkList.java
+++ b/RI/src/com/gsma/rcs/ri/messaging/TalkList.java
@@ -152,21 +152,19 @@ public class TalkList extends RcsActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         try {
-            switch (item.getItemId()) {
-                case R.id.menu_clear_log:
-                    /* Delete all messages */
-                    if (!isServiceConnected(RcsServiceName.CHAT, RcsServiceName.FILE_TRANSFER)) {
-                        showMessage(R.string.label_service_not_available);
-                        break;
-                    }
-                    if (LogUtils.isActive) {
-                        Log.d(LOGTAG, "delete conversations");
-                    }
-                    mChatService.deleteOneToOneChats();
-                    mChatService.deleteGroupChats();
-                    mFileTransferService.deleteOneToOneFileTransfers();
-                    mFileTransferService.deleteGroupFileTransfers();
-                    break;
+            if (item.getItemId() == R.id.menu_clear_log) {
+                /* Delete all messages */
+                if (!isServiceConnected(RcsServiceName.CHAT, RcsServiceName.FILE_TRANSFER)) {
+                    showMessage(R.string.label_service_not_available);
+                    return true;
+                }
+                if (LogUtils.isActive) {
+                    Log.d(LOGTAG, "delete conversations");
+                }
+                mChatService.deleteOneToOneChats();
+                mChatService.deleteGroupChats();
+                mFileTransferService.deleteOneToOneFileTransfers();
+                mFileTransferService.deleteGroupFileTransfers();
             }
         } catch (RcsServiceNotAvailableException e) {
             showMessage(R.string.label_service_not_available);
@@ -195,27 +193,24 @@ public class TalkList extends RcsActivity {
             Log.d(LOGTAG, "onContextItemSelected chatId=".concat(chatId));
         }
         try {
-            switch (item.getItemId()) {
-                case R.id.menu_delete_message:
-                    if (!isServiceConnected(RcsServiceName.CHAT, RcsServiceName.FILE_TRANSFER)) {
-                        showMessage(R.string.error_conversation_delete);
-                        return true;
-                    }
-                    if (LogUtils.isActive) {
-                        Log.d(LOGTAG, "Delete conversation for chatId=".concat(chatId));
-                    }
-                    if (message.isGroupChat()) {
-                        mChatService.deleteGroupChat(chatId);
-                        mFileTransferService.deleteGroupFileTransfers(chatId);
-                    } else {
-                        mChatService.deleteOneToOneChat(contact);
-                        mFileTransferService.deleteOneToOneFileTransfers(contact);
-                    }
+            if (item.getItemId() == R.id.menu_delete_message) {
+                if (!isServiceConnected(RcsServiceName.CHAT, RcsServiceName.FILE_TRANSFER)) {
+                    showMessage(R.string.error_conversation_delete);
                     return true;
-
-                default:
-                    return super.onContextItemSelected(item);
+                }
+                if (LogUtils.isActive) {
+                    Log.d(LOGTAG, "Delete conversation for chatId=".concat(chatId));
+                }
+                if (message.isGroupChat()) {
+                    mChatService.deleteGroupChat(chatId);
+                    mFileTransferService.deleteGroupFileTransfers(chatId);
+                } else {
+                    mChatService.deleteOneToOneChat(contact);
+                    mFileTransferService.deleteOneToOneFileTransfers(contact);
+                }
+                return true;
             }
+            return super.onContextItemSelected(item);
         } catch (RcsServiceException e) {
             showExceptionThenExit(e);
             return true;
@@ -262,12 +257,12 @@ public class TalkList extends RcsActivity {
         mOneToOneFileTransferListener = new OneToOneFileTransferListener() {
             @Override
             public void onStateChanged(ContactId contact, String transferId,
-                    FileTransfer.State state, FileTransfer.ReasonCode reasonCode) {
+                                       FileTransfer.State state, FileTransfer.ReasonCode reasonCode) {
             }
 
             @Override
             public void onProgressUpdate(ContactId contact, String transferId, long currentSize,
-                    long totalSize) {
+                                         long totalSize) {
             }
 
             @Override
@@ -281,8 +276,8 @@ public class TalkList extends RcsActivity {
         mOneToOneChatListener = new OneToOneChatListener() {
             @Override
             public void onMessageStatusChanged(ContactId contact, String mimeType, String msgId,
-                    ChatLog.Message.Content.Status status,
-                    ChatLog.Message.Content.ReasonCode reasonCode) {
+                                               ChatLog.Message.Content.Status status,
+                                               ChatLog.Message.Content.ReasonCode reasonCode) {
             }
 
             @Override
@@ -300,17 +295,17 @@ public class TalkList extends RcsActivity {
         mGroupFileTransferListener = new GroupFileTransferListener() {
             @Override
             public void onStateChanged(String chatId, String transferId, FileTransfer.State state,
-                    FileTransfer.ReasonCode reasonCode) {
+                                       FileTransfer.ReasonCode reasonCode) {
             }
 
             @Override
             public void onDeliveryInfoChanged(String chatId, ContactId contact, String transferId,
-                    GroupDeliveryInfo.Status status, GroupDeliveryInfo.ReasonCode reasonCode) {
+                                              GroupDeliveryInfo.Status status, GroupDeliveryInfo.ReasonCode reasonCode) {
             }
 
             @Override
             public void onProgressUpdate(String chatId, String transferId, long currentSize,
-                    long totalSize) {
+                                         long totalSize) {
             }
 
             @Override
@@ -324,7 +319,7 @@ public class TalkList extends RcsActivity {
         mGroupChatListener = new GroupChatListener() {
             @Override
             public void onStateChanged(String chatId, GroupChat.State state,
-                    GroupChat.ReasonCode reasonCode) {
+                                       GroupChat.ReasonCode reasonCode) {
             }
 
             @Override
@@ -333,19 +328,19 @@ public class TalkList extends RcsActivity {
 
             @Override
             public void onMessageStatusChanged(String chatId, String mimeType, String msgId,
-                    ChatLog.Message.Content.Status status,
-                    ChatLog.Message.Content.ReasonCode reasonCode) {
+                                               ChatLog.Message.Content.Status status,
+                                               ChatLog.Message.Content.ReasonCode reasonCode) {
             }
 
             @Override
             public void onMessageGroupDeliveryInfoChanged(String chatId, ContactId contact,
-                    String mimeType, String msgId, GroupDeliveryInfo.Status status,
-                    GroupDeliveryInfo.ReasonCode reasonCode) {
+                                                          String mimeType, String msgId, GroupDeliveryInfo.Status status,
+                                                          GroupDeliveryInfo.ReasonCode reasonCode) {
             }
 
             @Override
             public void onParticipantStatusChanged(String chatId, ContactId contact,
-                    GroupChat.ParticipantStatus status) {
+                                                   GroupChat.ParticipantStatus status) {
             }
 
             @Override
@@ -394,7 +389,7 @@ public class TalkList extends RcsActivity {
     /**
      * Notify new conversation event
      *
-     * @param ctx the context
+     * @param ctx    the context
      * @param action the action intent
      */
     public static void notifyNewConversationEvent(Context ctx, String action) {

--- a/RI/src/com/gsma/rcs/ri/messaging/chat/SendFile.java
+++ b/RI/src/com/gsma/rcs/ri/messaging/chat/SendFile.java
@@ -273,14 +273,12 @@ public abstract class SendFile extends RcsActivity implements ISendFile {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_record_audio:
-                startActivityForResult(new Intent(this, AudioMessageRecordActivity.class),
-                        RC_RECORD_AUDIO);
-                break;
-            case R.id.menu_close_session:
-                quitSession();
-                break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.menu_record_audio) {
+            startActivityForResult(new Intent(this, AudioMessageRecordActivity.class),
+                    RC_RECORD_AUDIO);
+        } else if (itemId == R.id.menu_close_session) {
+            quitSession();
         }
         return true;
     }

--- a/RI/src/com/gsma/rcs/ri/messaging/filetransfer/InitiateFileTransfer.java
+++ b/RI/src/com/gsma/rcs/ri/messaging/filetransfer/InitiateFileTransfer.java
@@ -377,14 +377,12 @@ public class InitiateFileTransfer extends RcsActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_record_audio:
-                startActivityForResult(new Intent(this, AudioMessageRecordActivity.class),
-                        RC_RECORD_AUDIO);
-                break;
-            case R.id.menu_close_session:
-                quitSession();
-                break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.menu_record_audio) {
+            startActivityForResult(new Intent(this, AudioMessageRecordActivity.class),
+                    RC_RECORD_AUDIO);
+        } else if (itemId == R.id.menu_close_session) {
+            quitSession();
         }
         return true;
     }

--- a/RI/src/com/gsma/rcs/ri/messaging/filetransfer/ReceiveFileTransfer.java
+++ b/RI/src/com/gsma/rcs/ri/messaging/filetransfer/ReceiveFileTransfer.java
@@ -386,10 +386,8 @@ public class ReceiveFileTransfer extends RcsActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_close_session:
-                quitSession();
-                break;
+        if (item.getItemId() == R.id.menu_close_session) {
+            quitSession();
         }
         return true;
     }

--- a/RI/src/com/gsma/rcs/ri/messaging/filetransfer/multi/SendMultiFile.java
+++ b/RI/src/com/gsma/rcs/ri/messaging/filetransfer/multi/SendMultiFile.java
@@ -326,10 +326,8 @@ public abstract class SendMultiFile extends RcsActivity implements ISendMultiFil
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_close_session:
-                quitSession();
-                break;
+        if (item.getItemId() == R.id.menu_close_session) {
+            quitSession();
         }
         return true;
     }

--- a/RI/src/com/gsma/rcs/ri/sharing/SharingListView.java
+++ b/RI/src/com/gsma/rcs/ri/sharing/SharingListView.java
@@ -475,61 +475,58 @@ public class SharingListView extends RcsFragmentActivity implements
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_filter:
-                Builder builder = new Builder(this);
-                builder.setTitle(R.string.title_sharing_log_dialog_filter_logs);
-                builder.setMultiChoiceItems(
-                        mFilterMenuItems.toArray(new CharSequence[mFilterMenuItems.size()]),
-                        mCheckedProviders, new DialogInterface.OnMultiChoiceClickListener() {
-                            public void onClick(DialogInterface dialog, int which, boolean isChecked) {
-                                mCheckedProviders[which] = isChecked;
-                            }
-                        });
-                builder.setPositiveButton(R.string.label_ok, new OnClickListener() {
-                    public void onClick(DialogInterface dialog, int which) {
-                        mFilterAlertDialog.dismiss();
-                        queryHistoryLogAndRefreshView();
-                    }
-                });
-                builder.setNegativeButton(R.string.label_cancel, new OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        mFilterAlertDialog.dismiss();
-                    }
-                });
-                mFilterAlertDialog = builder.show();
-                registerDialog(mFilterAlertDialog);
-                break;
-
-            case R.id.menu_delete:
-                if (!isServiceConnected(RcsServiceName.IMAGE_SHARING, RcsServiceName.VIDEO_SHARING,
-                        RcsServiceName.GEOLOC_SHARING)) {
-                    showMessage(R.string.label_service_not_available);
-                    break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.menu_filter) {
+            Builder builder = new Builder(this);
+            builder.setTitle(R.string.title_sharing_log_dialog_filter_logs);
+            builder.setMultiChoiceItems(
+                    mFilterMenuItems.toArray(new CharSequence[mFilterMenuItems.size()]),
+                    mCheckedProviders, new DialogInterface.OnMultiChoiceClickListener() {
+                        public void onClick(DialogInterface dialog, int which, boolean isChecked) {
+                            mCheckedProviders[which] = isChecked;
+                        }
+                    });
+            builder.setPositiveButton(R.string.label_ok, new OnClickListener() {
+                public void onClick(DialogInterface dialog, int which) {
+                    mFilterAlertDialog.dismiss();
+                    queryHistoryLogAndRefreshView();
                 }
-                Log.d(LOGTAG, "delete all image sharing sessions");
-                try {
-                    if (!mImageSharingListenerSet) {
-                        mImageSharingService.addEventListener(mImageSharingListener);
-                        mImageSharingListenerSet = true;
-                    }
-                    mImageSharingService.deleteImageSharings();
-                    if (!mVideoSharingListenerSet) {
-                        mVideoSharingService.addEventListener(mVideoSharingListener);
-                        mVideoSharingListenerSet = true;
-                    }
-                    mVideoSharingService.deleteVideoSharings();
-                    if (!mGeolocSharingListenerSet) {
-                        mGeolocSharingService.addEventListener(mGeolocSharingListener);
-                        mGeolocSharingListenerSet = true;
-                    }
-                    mGeolocSharingService.deleteGeolocSharings();
-                } catch (RcsServiceException e) {
-                    showExceptionThenExit(e);
-
+            });
+            builder.setNegativeButton(R.string.label_cancel, new OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    mFilterAlertDialog.dismiss();
                 }
-                break;
+            });
+            mFilterAlertDialog = builder.show();
+            registerDialog(mFilterAlertDialog);
+        } else if (itemId == R.id.menu_delete) {
+            if (!isServiceConnected(RcsServiceName.IMAGE_SHARING, RcsServiceName.VIDEO_SHARING,
+                    RcsServiceName.GEOLOC_SHARING)) {
+                showMessage(R.string.label_service_not_available);
+                return true;
+            }
+            Log.d(LOGTAG, "delete all image sharing sessions");
+            try {
+                if (!mImageSharingListenerSet) {
+                    mImageSharingService.addEventListener(mImageSharingListener);
+                    mImageSharingListenerSet = true;
+                }
+                mImageSharingService.deleteImageSharings();
+                if (!mVideoSharingListenerSet) {
+                    mVideoSharingService.addEventListener(mVideoSharingListener);
+                    mVideoSharingListenerSet = true;
+                }
+                mVideoSharingService.deleteVideoSharings();
+                if (!mGeolocSharingListenerSet) {
+                    mGeolocSharingService.addEventListener(mGeolocSharingListener);
+                    mGeolocSharingListenerSet = true;
+                }
+                mGeolocSharingService.deleteGeolocSharings();
+            } catch (RcsServiceException e) {
+                showExceptionThenExit(e);
+
+            }
         }
         return true;
     }
@@ -570,43 +567,41 @@ public class SharingListView extends RcsFragmentActivity implements
             Log.d(LOGTAG, "onContextItemSelected sharing ID=".concat(sharingId));
         }
         try {
-            switch (item.getItemId()) {
-                case R.id.menu_sharing_delete:
-                    Log.d(LOGTAG, "Delete sharing ID=".concat(sharingId));
-                    switch (providerId) {
-                        case ImageSharingLog.HISTORYLOG_MEMBER_ID:
-                            if (!mImageSharingListenerSet) {
-                                mImageSharingService.addEventListener(mImageSharingListener);
-                                mImageSharingListenerSet = true;
-                            }
-                            mImageSharingService.deleteImageSharing(sharingId);
-                            return true;
+            int itemId = item.getItemId();
+            if (itemId == R.id.menu_sharing_delete) {
+                Log.d(LOGTAG, "Delete sharing ID=".concat(sharingId));
+                switch (providerId) {
+                    case ImageSharingLog.HISTORYLOG_MEMBER_ID:
+                        if (!mImageSharingListenerSet) {
+                            mImageSharingService.addEventListener(mImageSharingListener);
+                            mImageSharingListenerSet = true;
+                        }
+                        mImageSharingService.deleteImageSharing(sharingId);
+                        return true;
 
-                        case VideoSharingLog.HISTORYLOG_MEMBER_ID:
-                            if (!mVideoSharingListenerSet) {
-                                mVideoSharingService.addEventListener(mVideoSharingListener);
-                                mVideoSharingListenerSet = true;
-                            }
-                            mVideoSharingService.deleteVideoSharing(sharingId);
-                            return true;
-                        case GeolocSharingLog.HISTORYLOG_MEMBER_ID:
-                            if (!mGeolocSharingListenerSet) {
-                                mGeolocSharingService.addEventListener(mGeolocSharingListener);
-                                mGeolocSharingListenerSet = true;
-                            }
-                            mGeolocSharingService.deleteGeolocSharing(sharingId);
-                            return true;
-                        default:
-                            return true;
-                    }
-                case R.id.menu_sharing_display:
-                    Utils.showPicture(this, Uri.parse(cursor.getString(cursor
-                            .getColumnIndexOrThrow(HistoryLog.CONTENT))));
-                    return true;
-
-                default:
-                    return super.onContextItemSelected(item);
+                    case VideoSharingLog.HISTORYLOG_MEMBER_ID:
+                        if (!mVideoSharingListenerSet) {
+                            mVideoSharingService.addEventListener(mVideoSharingListener);
+                            mVideoSharingListenerSet = true;
+                        }
+                        mVideoSharingService.deleteVideoSharing(sharingId);
+                        return true;
+                    case GeolocSharingLog.HISTORYLOG_MEMBER_ID:
+                        if (!mGeolocSharingListenerSet) {
+                            mGeolocSharingService.addEventListener(mGeolocSharingListener);
+                            mGeolocSharingListenerSet = true;
+                        }
+                        mGeolocSharingService.deleteGeolocSharing(sharingId);
+                        return true;
+                    default:
+                        return true;
+                }
+            } else if (itemId == R.id.menu_sharing_display) {
+                Utils.showPicture(this, Uri.parse(cursor.getString(cursor
+                        .getColumnIndexOrThrow(HistoryLog.CONTENT))));
+                return true;
             }
+            return super.onContextItemSelected(item);
         } catch (RcsServiceNotAvailableException e) {
             showMessage(R.string.label_service_not_available);
             return true;

--- a/RI/src/com/gsma/rcs/ri/sharing/geoloc/InitiateGeolocSharing.java
+++ b/RI/src/com/gsma/rcs/ri/sharing/geoloc/InitiateGeolocSharing.java
@@ -185,10 +185,8 @@ public class InitiateGeolocSharing extends RcsActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_close_session:
-                quitSession();
-                break;
+        if (item.getItemId() == R.id.menu_close_session) {
+            quitSession();
         }
         return true;
     }

--- a/RI/src/com/gsma/rcs/ri/sharing/geoloc/ReceiveGeolocSharing.java
+++ b/RI/src/com/gsma/rcs/ri/sharing/geoloc/ReceiveGeolocSharing.java
@@ -216,10 +216,8 @@ public class ReceiveGeolocSharing extends RcsActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_close_session:
-                quitSession();
-                break;
+        if (item.getItemId() == R.id.menu_close_session) {
+            quitSession();
         }
         return true;
     }

--- a/RI/src/com/gsma/rcs/ri/sharing/image/InitiateImageSharing.java
+++ b/RI/src/com/gsma/rcs/ri/sharing/image/InitiateImageSharing.java
@@ -220,10 +220,8 @@ public class InitiateImageSharing extends RcsActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_close_session:
-                quitSession();
-                break;
+        if (item.getItemId() == R.id.menu_close_session) {
+            quitSession();
         }
         return true;
     }

--- a/RI/src/com/gsma/rcs/ri/sharing/image/ReceiveImageSharing.java
+++ b/RI/src/com/gsma/rcs/ri/sharing/image/ReceiveImageSharing.java
@@ -243,10 +243,8 @@ public class ReceiveImageSharing extends RcsActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_close_session:
-                quitSession();
-                break;
+        if (item.getItemId() == R.id.menu_close_session) {
+            quitSession();
         }
         return true;
     }

--- a/RI/src/com/gsma/rcs/ri/sharing/video/IncomingVideoSharing.java
+++ b/RI/src/com/gsma/rcs/ri/sharing/video/IncomingVideoSharing.java
@@ -331,10 +331,8 @@ public class IncomingVideoSharing extends RcsActivity implements VideoPlayerList
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_close_session:
-                quitSession();
-                break;
+        if (item.getItemId() == R.id.menu_close_session) {
+            quitSession();
         }
         return true;
     }

--- a/RI/src/com/gsma/rcs/ri/sharing/video/OutgoingVideoSharing.java
+++ b/RI/src/com/gsma/rcs/ri/sharing/video/OutgoingVideoSharing.java
@@ -520,10 +520,8 @@ public class OutgoingVideoSharing extends RcsActivity implements VideoPlayerList
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_close_session:
-                quitSession();
-                break;
+        if (item.getItemId() == R.id.menu_close_session) {
+            quitSession();
         }
         return true;
     }

--- a/build.gradle
+++ b/build.gradle
@@ -20,4 +20,4 @@ allprojects {
 project.ext.set("compileSdkVersion", 23)
 project.ext.set("minSdkVersion", 12)
 project.ext.set("targetSdkVersion", 23)
-project.ext.set("buildToolsVersion", "24.0.0")
+project.ext.set("buildToolsVersion", "35.0.0")

--- a/build.gradle
+++ b/build.gradle
@@ -2,16 +2,18 @@
 
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:8.13.0'
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'com.gsma.rcs'
 
     //Required to support the old folder structure
     sourceSets {
@@ -8,7 +9,6 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
             resources.srcDirs = ['src']
-            aidl.srcDirs = ['src']
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,10 +40,10 @@ android {
 }
 
 dependencies {
-    compile project(':bouncycastle')
-    compile project(':nist_sip')
-    compile project(':api')
-    compile 'dnsjava:dnsjava:2.1.7'
-    compile 'com.android.support:support-v4:25.0.1'
-    compile 'com.android.support:appcompat-v7:25.0.1'
+    implementation project(':bouncycastle')
+    implementation project(':nist_sip')
+    implementation project(':api')
+    implementation 'dnsjava:dnsjava:2.1.7'
+    implementation 'com.android.support:support-v4:25.0.1'
+    implementation 'com.android.support:appcompat-v7:25.0.1'
 }

--- a/core/src/com/gsma/rcs/provisioning/local/Provisioning.java
+++ b/core/src/com/gsma/rcs/provisioning/local/Provisioning.java
@@ -159,32 +159,28 @@ public class Provisioning extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.save:
-                if (sLogger.isActivated()) {
-                    sLogger.debug("Save provisioning");
-                }
-                for (IProvisioningFragment fragment : mAdapter.getFragments()) {
-                    fragment.persistRcsSettings();
-                }
-                Toast.makeText(this, getString(R.string.label_reboot_service), Toast.LENGTH_LONG)
-                        .show();
-                return true;
-
-            case R.id.load:
-                if (sLogger.isActivated()) {
-                    sLogger.debug("Load provisioning");
-                }
-                loadXmlFile();
-                return true;
-
-            case R.id.about:
-                displayInfo();
-                return true;
-
-            default:
-                return super.onOptionsItemSelected(item);
+        int itemId = item.getItemId();
+        if (itemId == R.id.save) {
+            if (sLogger.isActivated()) {
+                sLogger.debug("Save provisioning");
+            }
+            for (IProvisioningFragment fragment : mAdapter.getFragments()) {
+                fragment.persistRcsSettings();
+            }
+            Toast.makeText(this, getString(R.string.label_reboot_service), Toast.LENGTH_LONG)
+                    .show();
+            return true;
+        } else if (itemId == R.id.load) {
+            if (sLogger.isActivated()) {
+                sLogger.debug("Load provisioning");
+            }
+            loadXmlFile();
+            return true;
+        } else if (itemId == R.id.about) {
+            displayInfo();
+            return true;
         }
+        return super.onOptionsItemSelected(item);
     }
 
     /**

--- a/core/tests/AndroidManifest.xml
+++ b/core/tests/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- package name must be unique so suffix with "tests" so package loader doesn't ignore us -->
-<manifest package="com.gsma.rcs.tests"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!--
       We add an application tag here just so that we can indicate that

--- a/core/tests/src/com/gsma/rcs/utils/Base64Test.java
+++ b/core/tests/src/com/gsma/rcs/utils/Base64Test.java
@@ -24,15 +24,15 @@ public class Base64Test extends AndroidTestCase {
 
     public final void testBase64() {
         String ss = "2 + 2 = quatre, non 5?";
-        assertEquals(Base64.encodeBase64ToString(ss.getBytes()), "MiArIDIgPSBxdWF0cmUsIG5vbiA1Pw==");
-        assertEquals(new String(Base64.encodeBase64(ss.getBytes())),
-                "MiArIDIgPSBxdWF0cmUsIG5vbiA1Pw==");
-        assertEquals(Base64.encodeBase64ToString(Base64
-                .decodeBase64(("MiArIDIgPSBxdWF0cmUsIG5vbiA1Pw==").getBytes())),
-                "MiArIDIgPSBxdWF0cmUsIG5vbiA1Pw==");
+        assertEquals("MiArIDIgPSBxdWF0cmUsIG5vbiA1Pw==", Base64.encodeBase64ToString(ss.getBytes()));
+        assertEquals("MiArIDIgPSBxdWF0cmUsIG5vbiA1Pw==",
+                new String(Base64.encodeBase64(ss.getBytes())));
+        assertEquals("MiArIDIgPSBxdWF0cmUsIG5vbiA1Pw==",
+                Base64.encodeBase64ToString(Base64
+                        .decodeBase64(("MiArIDIgPSBxdWF0cmUsIG5vbiA1Pw==").getBytes())));
         assertEquals(
-                new String(Base64.decodeBase64(("MiArIDIgPSBxdWF0cmUsIG5vbiA1Pw==").getBytes())),
-                ss);
+                ss,
+                new String(Base64.decodeBase64(("MiArIDIgPSBxdWF0cmUsIG5vbiA1Pw==").getBytes())));
     }
 
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 15 09:18:52 CET 2016
+#Thu Nov 06 23:42:38 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/libs/api/build.gradle
+++ b/libs/api/build.gradle
@@ -4,17 +4,17 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-	lintOptions {
-		abortOnError false
-	}
+    lintOptions {
+        abortOnError false
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-	
-	defaultConfig {
+
+    defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
     }
@@ -42,13 +42,13 @@ task javadoc(type: Javadoc) {
     options {
         doclet "com.google.doclava.Doclava"
         bootClasspath new File(System.getenv('JAVA_HOME') + "/jre/lib/rt.jar")
-		addStringOption "d", "./build/docs/javadoc"
+        addStringOption "d", "./build/docs/javadoc"
         addStringOption "hdf project.name", "RCS API"
         addStringOption "hdf sdk.version", "1.6"
         addStringOption "title", "TAPI 1.6.1"
         addStringOption "federate android", "http://developer.android.com/reference/"
         addStringOption "federationxml android", "http://doclava.googlecode.com/svn/static/api/android-10.xml"
         addStringOption "since ./version/blackbird_1_5_1.xml", "1.5"
-		addStringOption "since ./version/crane_1_6_1.xml", "1.6"
+        addStringOption "since ./version/crane_1_6_1.xml", "1.6"
     }
 }

--- a/libs/api/build.gradle
+++ b/libs/api/build.gradle
@@ -1,8 +1,17 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.gsma.services.rcs'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
+
+    sourceSets {
+        main {
+            manifest.srcFile 'src/main/AndroidManifest.xml'
+            java.srcDirs = ['src/main/java']
+            aidl.srcDirs = ['src/main/aidl']
+        }
+    }
 
     lintOptions {
         abortOnError false
@@ -17,6 +26,10 @@ android {
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.targetSdkVersion
+    }
+
+    buildFeatures {
+        aidl true
     }
 }
 

--- a/libs/api_cnx/build.gradle
+++ b/libs/api_cnx/build.gradle
@@ -4,9 +4,9 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
-	lintOptions {
-		abortOnError false
-	}
+    lintOptions {
+        abortOnError false
+    }
     buildTypes {
         release {
             minifyEnabled false
@@ -21,6 +21,6 @@ android {
 }
 
 dependencies {
-    compile project(':api')
-	compile 'com.android.support:support-v4:25.0.1'
+    implementation project(':api')
+    implementation 'com.android.support:support-v4:25.0.1'
 }

--- a/libs/api_cnx/build.gradle
+++ b/libs/api_cnx/build.gradle
@@ -1,8 +1,15 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.gsma.rcs.api.connection'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
+
+    sourceSets {
+        main {
+            manifest.srcFile 'src/main/AndroidManifest.xml'
+        }
+    }
 
     lintOptions {
         abortOnError false

--- a/libs/bouncycastle/build.gradle
+++ b/libs/bouncycastle/build.gradle
@@ -21,5 +21,5 @@ android {
     lintOptions {
         abortOnError false
     }
-	
+
 }

--- a/libs/bouncycastle/build.gradle
+++ b/libs/bouncycastle/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace "local.org.bouncycastle"
+
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
@@ -10,7 +12,6 @@ android {
             manifest.srcFile 'AndroidManifestLibrary.xml'
             java.srcDirs = ['src']
             resources.srcDirs = ['src']
-            aidl.srcDirs = ['src']
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']

--- a/libs/nist_sip/build.gradle
+++ b/libs/nist_sip/build.gradle
@@ -21,5 +21,5 @@ android {
     lintOptions {
         abortOnError false
     }
-	
+
 }

--- a/libs/nist_sip/build.gradle
+++ b/libs/nist_sip/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace "gov2.nist"
+
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
@@ -10,7 +12,6 @@ android {
             manifest.srcFile 'AndroidManifestLibrary.xml'
             java.srcDirs = ['src']
             resources.srcDirs = ['src']
-            aidl.srcDirs = ['src']
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']

--- a/mediaplayer/build.gradle
+++ b/mediaplayer/build.gradle
@@ -4,6 +4,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.orangelabs.rcs'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
 
@@ -13,7 +14,6 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
             resources.srcDirs = ['src']
-            aidl.srcDirs = ['src']
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']

--- a/samples/api/extension/build.gradle
+++ b/samples/api/extension/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'com.gsma.services.rcs.samples.extension'
 
     //Required to support the old folder structure
     sourceSets {
@@ -8,7 +9,6 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
             resources.srcDirs = ['src']
-            aidl.srcDirs = ['src']
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']

--- a/samples/api/tts/build.gradle
+++ b/samples/api/tts/build.gradle
@@ -36,14 +36,16 @@ android {
 }
 
 dependencies {
-    compile project(':api')
-    compile 'com.android.support:support-v4:25.0.1'
+    implementation project(':api')
+    implementation 'com.android.support:support-v4:25.0.1'
 }
 
 //Below install dependecy was added to always install RCS service before
 //a RCS client to secure that Android handles RCS permissions correctly.
-task installServiceFirst(dependsOn: ':core:installDebug') << {
-    println 'RCS core service was installed first!'
+task installServiceFirst(dependsOn: ':core:installDebug') {
+    doLast {
+        println 'RCS core service was installed first!'
+    }
 }
 tasks.whenTaskAdded { task ->
     if (task.name == 'installDebug') {

--- a/samples/api/tts/build.gradle
+++ b/samples/api/tts/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'com.orangelabs.rcs.tts'
 
     //Required to support the old folder structure
     sourceSets {
@@ -8,7 +9,6 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
             resources.srcDirs = ['src']
-            aidl.srcDirs = ['src']
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']

--- a/tests/cts/provider/build.gradle
+++ b/tests/cts/provider/build.gradle
@@ -16,7 +16,7 @@ android {
 
 dependencies {
     // Testing-only dependencies
-    androidTestCompile 'com.android.support.test:runner:0.4.1'
-    androidTestCompile 'com.android.support.test:rules:0.4.1'
-	compile project(':api')
+    androidTestImplementation 'com.android.support.test:runner:0.4.1'
+    androidTestImplementation 'com.android.support.test:rules:0.4.1'
+    implementation project(':api')
 }

--- a/tests/cts/provider/build.gradle
+++ b/tests/cts/provider/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-	
+
     defaultConfig {
         applicationId "android.tests.provider"
         minSdkVersion rootProject.minSdkVersion

--- a/tests/cts/provider/build.gradle
+++ b/tests/cts/provider/build.gradle
@@ -1,8 +1,15 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'android.tests.provider'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
+
+    sourceSets {
+        main {
+            manifest.srcFile 'src/main/AndroidManifest.xml'
+        }
+    }
 
     defaultConfig {
         applicationId "android.tests.provider"

--- a/tests/cts/signature/build.gradle
+++ b/tests/cts/signature/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-	
+
     defaultConfig {
         applicationId "android.tests.sigtest"
         minSdkVersion rootProject.minSdkVersion

--- a/tests/cts/signature/build.gradle
+++ b/tests/cts/signature/build.gradle
@@ -16,8 +16,8 @@ android {
 
 dependencies {
     // Testing-only dependencies
-    androidTestCompile 'com.android.support.test:runner:0.4.1'
-    androidTestCompile 'com.android.support.test:rules:0.4.1'
-	
-	compile files('libs/rcs_api.jar')
+    androidTestImplementation 'com.android.support.test:runner:0.4.1'
+    androidTestImplementation 'com.android.support.test:rules:0.4.1'
+
+    implementation files('libs/rcs_api.jar')
 }

--- a/tests/cts/signature/build.gradle
+++ b/tests/cts/signature/build.gradle
@@ -1,8 +1,15 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'android.tests.sigtest'
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
+
+    sourceSets {
+        main {
+            manifest.srcFile 'src/main/AndroidManifest.xml'
+        }
+    }
 
     defaultConfig {
         applicationId "android.tests.sigtest"

--- a/tools/notification/build.gradle
+++ b/tools/notification/build.gradle
@@ -36,14 +36,16 @@ android {
 }
 
 dependencies {
-    compile project(':api')
-    compile 'com.android.support:support-v4:25.0.1'
+    implementation project(':api')
+    implementation 'com.android.support:support-v4:25.0.1'
 }
 
 //Below install dependecy was added to always install RCS service before
 //a RCS client to secure that Android handles RCS permissions correctly.
-task installServiceFirst(dependsOn: ':core:installDebug') << {
-    println 'RCS core service was installed first!'
+task installServiceFirst(dependsOn: ':core:installDebug') {
+    doLast {
+        println 'RCS core service was installed first!'
+    }
 }
 tasks.whenTaskAdded { task ->
     if (task.name == 'installDebug') {

--- a/tools/notification/build.gradle
+++ b/tools/notification/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'com.gsma.rcs.registry'
 
     //Required to support the old folder structure
     sourceSets {
@@ -8,7 +9,6 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
             resources.srcDirs = ['src']
-            aidl.srcDirs = ['src']
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']

--- a/tools/provisioning/build.gradle
+++ b/tools/provisioning/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'com.gsma.rcs.tools.http.provisioning'
 
     //Required to support the old folder structure
     sourceSets {
@@ -8,7 +9,6 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
             resources.srcDirs = ['src']
-            aidl.srcDirs = ['src']
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']

--- a/tools/settings/build.gradle
+++ b/tools/settings/build.gradle
@@ -36,14 +36,16 @@ android {
 }
 
 dependencies {
-    compile project(':api')
-    compile project(':api_cnx')
+    implementation project(':api')
+    implementation project(':api_cnx')
 }
 
 //Below install dependecy was added to always install RCS service before
 //a RCS client to secure that Android handles RCS permissions correctly.
-task installServiceFirst(dependsOn: ':core:installDebug') << {
-    println 'RCS core service was installed first!'
+task installServiceFirst(dependsOn: ':core:installDebug') {
+    doLast {
+        println 'RCS core service was installed first!'
+    }
 }
 tasks.whenTaskAdded { task ->
     if (task.name == 'installDebug') {

--- a/tools/settings/build.gradle
+++ b/tools/settings/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'com.gsma.rcs.core.control'
 
     //Required to support the old folder structure
     sourceSets {
@@ -8,7 +9,6 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
             resources.srcDirs = ['src']
-            aidl.srcDirs = ['src']
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']


### PR DESCRIPTION
A few changes rolled into one to get this project into a "you can open it in the current Android Studio and it can build and run tests" state.

I have NOT been doing Android work consistently over the past 10 years that this project has existed though, so I'm not 100% confident about this PR.  
It works for me and I've tried to make reasonably sure everything is correct, but major build-system upgrades like this tend to have a lot of subtle surprises that are hard to learn about years afterward :\

So I, personally, would be happy enough using this - it seems functional enough and nobody should be depending on this project in any sensitive way.  But obviously the final decision is yours, and I have no solid evidence that it's actually correct :)

---

seems-definitely-required changes:
- `compile` -> `implements` dependency-type rename
- `<<` -> `doLast`, as `<<` is fully removed now
- copied the `AndroidManifest.xml` namespace into the relevant `build.gradle` files, and updated the `manifest.srcFile` because apparently the default location has moved and it wasn't finding most
- enabled AIDL build feature in `libs/api/...` (the only sub-project that needs it)
- removed a test-only `AndroidManifest.xml` namespace, as the build tools said that wasn't allowed.  unfortunately I'm not sure if this has any consequences, but even if it does it seems almost certainly limited to test-related activities?  like at worst it might replace the non-test app rather than installing along-side it.
- `switch(...) { case R.id.xyz` -> `if (... == R.id.xyz)` automated rewrite via Android Studio's refactor tool
  - I forget when this changed, but `R.id.xyz` is no longer a build-time constant, so it cannot be used in a switch statement.  There might be a way to change the build to restore this, but my brief attempts didn't work, and it didn't seem worth spending more effort on when I have an automated rewriter.
  - I have not carefully checked all of these, but as it's not an AI tool I feel it's probably trustworthy, and it seems to work
  - only one needed to be rewritten by hand, `onOptionsItemSelected` in `RI/src/com/gsma/rcs/ri/messaging/TalkList.java`
- explicit paths to `manifest.srcFile` when needed in `build.gradle` files, as the default location has moved
  - it's likely better to move those files to the new default location, but I'm trying to be minimal and I'm not sure how to be confident that it'll be a safe no-op.
- upgraded gradle to a relatively-modern version
- upgraded build tools, as the IDE was telling me that the older version was being ignored
  - I have not checked if this has any other important impacts, but it can build and run tests with no noteworthy warnings so it seems likely fine

other minor non-functional changes that I happened to see:
- some indentation changes in files that also had other changes, e.g. `R.id` switch rewrites.
  - these were made by a brand new Android Studio install on Linux with absolutely no customization, so they feel pretty likely to be stable.  it's easy to undo if you'd prefer to do a separate "modernize indents in all code" commit or something though.
- all `\t` characters in `build.gradle` files changed to four spaces, and whitespace trailers removed, to be consistent.
  - it was making diffs annoying to read, so I just normalized it all after the fourth one.
- `assertEquals` args on a test I happened to look at were backwards, so I swapped them (should be `expected, actual`).
  - this was done by android studio's "swap arguments" refactor, and tests passed both before and after, and it looks reasonable at a glance.  pretty sure it's correct.

A somewhat annoyingly large set of changes for review purposes (sorry!), but I've tried to keep it fairly reasonable and limited in focus.

I'm still trying to find any other problems I may have missed, but I can run the `testUnitDebugTest` gradle target successfully now, except for emulator-run tests that require a telephony stack (other in-emulator tests succeed).